### PR TITLE
chore: add TypeScript as a dependency in package.json and package-loc…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "cross-env": "^7.0.3",
         "prettier": "^3.3.2",
         "tsx": "^4.16.2",
+        "typescript": "^5.8.3",
         "vitest": "^2.1.5"
       },
       "engines": {
@@ -4581,6 +4582,20 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/ufo": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "cross-env": "^7.0.3",
     "prettier": "^3.3.2",
     "tsx": "^4.16.2",
+    "typescript": "^5.8.3",
     "vitest": "^2.1.5"
   }
 }


### PR DESCRIPTION
…k.json

- Included TypeScript version 5.8.3 in both package.json and package-lock.json to ensure it is available for development and build processes.