### PR TITLE
refactor: rename translations to custom titles for clarity

### DIFF
--- a/packages/addon/src/meta.ts
+++ b/packages/addon/src/meta.ts
@@ -2,8 +2,8 @@ import { extractDigits, getAlternativeTitles } from './utils';
 
 export type MetaProviderResponse = {
   name: string;
-  originalName?: string; // Original name before any translation
-  alternativeNames?: string[]; // Alternative names/translations
+  originalName?: string; // Original name before any custom titles
+  alternativeNames?: string[]; // Alternative names/custom titles
   year?: number;
   season?: string;
   episode?: string;
@@ -20,7 +20,7 @@ export async function imdbMetaProvider(
       return json.d.find((item: { id: string }) => item.id === tt);
     })
     .then(({ l, y }) => {
-      // Get original name and potential translations
+      // Get original name and potential custom titles
       const originalName = l;
       const alternativeNames = getAlternativeTitles(originalName);
 
@@ -48,7 +48,7 @@ export async function cinemetaMetaProvider(
       const name = meta.name;
       const year = extractDigits(meta.year ?? meta.releaseInfo);
 
-      // Get original name and potential translations
+      // Get original name and potential custom titles
       const originalName = name;
       const alternativeNames = getAlternativeTitles(originalName);
 


### PR DESCRIPTION
- Updated variable names and comments in addon.ts, meta.ts, and utils.ts to replace "translations" with "custom titles" for improved clarity and consistency.
- Adjusted logging messages to reflect the new terminology, ensuring accurate representation of the data being handled.
- Enhanced documentation comments to align with the updated naming conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated variable and comment terminology from "translations" to "titles" and "custom titles" throughout the addon for improved clarity and consistency.
  - Adjusted related log messages and documentation to reflect the new naming conventions.
- **Documentation**
  - Revised type comments and inline documentation to use "custom titles" instead of "translations" for better accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->