### PR TITLE
fix: package versions and descriptions to 1.0.0

### DIFF
--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easynews-plus-plus-addon",
-  "version": "2.0.1",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "scripts": {
     "test": "vitest run --passWithNoTests",
@@ -10,12 +10,12 @@
     "start": "node dist/server.js",
     "start:dev": "cross-env NODE_ENV=dev tsx watch src/server.ts"
   },
-  "description": "Easynews++ is an open-source addon that enhances the Easynews experience with superior performance, advanced search capabilities, and intelligent stream selection. It features custom title support, multi-platform compatibility, and self-hosting options. Join our community on Discord (discord.gg/Ma4SnagqwE) or contribute on GitHub (github.com/panteLx/easynews-plus-plus).",
+  "description": "Addon package for Easynews++",
   "devDependencies": {
     "@types/stremio-addon-sdk": "^1.6.11"
   },
   "dependencies": {
-    "easynews-plus-plus-api": "^2.0.0",
+    "easynews-plus-plus-api": "workspace:*",
     "parse-torrent-title": "^1.4.0",
     "stremio-addon-sdk": "^1.6.10"
   }

--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -15,7 +15,7 @@
     "@types/stremio-addon-sdk": "^1.6.11"
   },
   "dependencies": {
-    "easynews-plus-plus-api": "workspace:*",
+    "easynews-plus-plus-api": "file:../api",
     "parse-torrent-title": "^1.4.0",
     "stremio-addon-sdk": "^1.6.10"
   }

--- a/packages/addon/src/manifest.ts
+++ b/packages/addon/src/manifest.ts
@@ -1,7 +1,7 @@
 import { Manifest, ManifestCatalog, ContentType } from 'stremio-addon-sdk';
 import { translations, DEFAULT_LANGUAGE } from './i18n';
 
-const { version, description } = require('../package.json');
+import { version, description } from '../../../package.json';
 
 // Prepare catalog structure
 export const catalog: ManifestCatalog = {

--- a/packages/addon/src/utils.ts
+++ b/packages/addon/src/utils.ts
@@ -615,7 +615,7 @@ export function buildSearchQuery(
  */
 export function getVersion(): string {
   try {
-    const version = require('../package.json').version;
+    const version = require('../../../package.json').version;
     return version;
   } catch (error) {
     return 'unknown-version';

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,10 +1,10 @@
 {
   "name": "easynews-plus-plus-api",
-  "version": "2.0.1",
+  "version": "1.0.0",
   "main": "./dist/index.js",
   "scripts": {
     "test": "vitest run --passWithNoTests",
     "build": "tsc"
   },
-  "description": "Easynews API library"
+  "description": "API package for Easynews++"
 }

--- a/packages/cloudflare-worker/package.json
+++ b/packages/cloudflare-worker/package.json
@@ -10,7 +10,7 @@
     "build": "exit 0"
   },
   "dependencies": {
-    "easynews-plus-plus-addon": "workspace:*",
+    "easynews-plus-plus-addon": "file:../addon",
     "hono": "^4.5.3",
     "hono-stremio": "^0.1.1"
   },

--- a/packages/cloudflare-worker/package.json
+++ b/packages/cloudflare-worker/package.json
@@ -1,6 +1,7 @@
 {
   "name": "easynews-plus-plus-cloudflare-worker",
-  "version": "2.0.1",
+  "version": "1.0.0",
+  "description": "Cloudflare Worker package for Easynews++",
   "scripts": {
     "test": "vitest run --passWithNoTests",
     "dev": "wrangler dev src/index.ts",
@@ -9,7 +10,7 @@
     "build": "exit 0"
   },
   "dependencies": {
-    "easynews-plus-plus-addon": "^2.0.0",
+    "easynews-plus-plus-addon": "workspace:*",
     "hono": "^4.5.3",
     "hono-stremio": "^0.1.1"
   },


### PR DESCRIPTION
- Changed version numbers for addon, api, and cloudflare-worker packages from 2.0.1 to 1.0.0.
- Updated descriptions for addon and api packages to reflect their purpose more clearly.
- Adjusted import paths in manifest.ts and utils.ts to reference the correct package.json location.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated package versions and descriptions across multiple packages.
	- Changed certain dependencies to use local workspace references instead of published versions.
	- Adjusted internal references to package metadata to ensure correct version and description retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->