### PR TITLE
fix: update Dockerfile entrypoint and README instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,4 @@ COPY --from=builder /build/node_modules ./node_modules
 
 EXPOSE 1337
 
-ENTRYPOINT ["npm", "run", "start:addon"]
+ENTRYPOINT ["npm", "run", "start"]

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ $ npm run start
 Access the addon at `http://localhost:1337/`. Customize the port using the `PORT` environment variable:
 
 ```bash
-$ PORT=8080 npm run start:addon
+$ PORT=8080 npm run start
 ```
 
 ### ☁️ Cloud Deployment


### PR DESCRIPTION
- Changed the Dockerfile entrypoint from `start:addon` to `start` for consistency.
- Updated README to reflect the new npm command for starting the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated container startup to use the standard start script instead of the addon-specific script.

- **Documentation**
	- Corrected the README example to reflect the updated start script for customizing the port.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->