### PR TITLE
docs: update README to reflect Stremio Windows 5.x beta support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@
 - iOS (Fusion)
 - Stremio
   - Windows 4.x
+  - Windows 5.x (beta)
   - Linux
   - Web (Browser)
 
@@ -115,7 +116,6 @@
 #### ❌ **Currently Not Supported:**
 
 - Stremio:
-  - Windows 5.x (confirmed not working)
   - webOS (confirmed not working)
   - iOS
   - Android Mobile (confirmed not working)


### PR DESCRIPTION
- Added Windows 5.x (beta) to the supported platforms list for Stremio.
- Removed the note indicating Windows 5.x is not supported.