### PR TITLE
docs: update README to include Android Mobile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,12 +103,14 @@
   - Windows 5.x (beta)
   - Linux
   - Web (Browser)
+  - Android Mobile (beta)
 
 #### ⚠️ **Should Work (Untested):**
 
 - Stremio:
   - macOS
   - Android TV
+  - Android Mobile (stable)
   - Steam Deck
   - Raspberry Pi
   - Sony TV
@@ -119,7 +121,6 @@
 - Stremio:
   - webOS (confirmed not working)
   - iOS
-  - Android Mobile (confirmed not working)
   - Samsung TV
 
 > [!NOTE]  


### PR DESCRIPTION
- Added Android Mobile (beta) to the list of platforms that should work.
- Updated the "Should Work (Untested)" section to reflect Android Mobile (stable) and removed the note about it being confirmed not working.