### PR TITLE
refactor: remove getType utility and related logger calls

### DIFF
--- a/packages/addon/src/addon.ts
+++ b/packages/addon/src/addon.ts
@@ -16,7 +16,6 @@ import {
   logError,
   matchesTitle,
   getAlternativeTitles,
-  getType,
 } from './utils';
 import { EasynewsAPI, SearchOptions, EasynewsSearchResponse } from 'easynews-plus-plus-api';
 import { publicMetaProvider } from './meta';
@@ -35,9 +34,6 @@ interface AddonConfig {
   maxFileSize?: string; // Max file size in GB
   [key: string]: any;
 }
-
-// Set type for logger
-getType('addon');
 
 // Definiere ValidPosterShape als Workaround für fehlendes PosterShape-Type
 type ValidPosterShape = 'square' | 'regular' | 'landscape';

--- a/packages/addon/src/custom-template.ts
+++ b/packages/addon/src/custom-template.ts
@@ -1,6 +1,6 @@
 import { Manifest } from 'stremio-addon-sdk';
 import { getTranslations, ISO_TO_LANGUAGE } from './i18n';
-import { logger, getType } from './utils';
+import { logger } from './utils';
 
 function landingTemplate(manifest: Manifest): string {
   const configurationFields = manifest.config || [];
@@ -14,9 +14,6 @@ function landingTemplate(manifest: Manifest): string {
 
   // Get translations based on the default UI language
   const translations = getTranslations(defaultUILanguage);
-
-  // Get the type to use in the logger
-  getType('custom-template');
 
   // For debugging
   logger.debug(`Using UI language: ${defaultUILanguage}, translations found: ${!!translations}`);

--- a/packages/addon/src/server.ts
+++ b/packages/addon/src/server.ts
@@ -6,7 +6,7 @@ import path from 'path';
 import getRouter from 'stremio-addon-sdk/src/getRouter';
 import customTemplate from './custom-template';
 import { addonInterface } from './addon';
-import { logger, getVersion, getType } from './utils';
+import { logger, getVersion } from './utils';
 
 type ServerOptions = {
   port?: number;
@@ -129,8 +129,6 @@ serveHTTP(addonInterface, { port: +(process.env.PORT ?? 1337) }).catch(err => {
   logger.error('Server failed to start:', err);
   process.exitCode = 1;
 });
-
-getType('server');
 
 // Log environment configuration
 logger.info(`PORT: ${process.env.PORT || 1337}`);

--- a/packages/addon/src/utils.ts
+++ b/packages/addon/src/utils.ts
@@ -43,21 +43,6 @@ interface TypeFunction {
   currentType: string;
 }
 
-// Implement the function with proper typing
-export const getType: TypeFunction = function (type?: string): string {
-  // Store the module type in a variable that persists between calls
-  if (type) {
-    getType.currentType = type;
-  }
-  return getType.currentType || 'Easynews++';
-};
-
-// Initialize the property
-getType.currentType = '';
-
-// Initialize with 'utils' as the default type for this module
-getType('utils');
-
 export function isBadVideo(file: FileData) {
   const duration = file['14'] ?? '';
   const title = getPostTitle(file);
@@ -451,7 +436,7 @@ class CloudflareLogger {
   }
 
   private formatMessage(level: string, message: string, ...args: any[]): string {
-    let formattedMessage = `[${getType()} - v${getVersion()}] ${level.toUpperCase()}: ${message}`;
+    let formattedMessage = `[v${getVersion()}] ${level.toUpperCase()}: ${message}`;
 
     if (args.length > 0) {
       const formattedArgs = args
@@ -527,7 +512,7 @@ export const logger = (() => {
           message = `${message} ${args}`;
         }
 
-        return `[${getType()} - v${getVersion()}] ${info.level}: ${message}`;
+        return `[v${getVersion()}] ${info.level}: ${message}`;
       })
     ),
     transports: [new winston.transports.Console()],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified logging by removing the module type prefix from log messages across the addon package.
  - Streamlined code by eliminating the `getType` utility and its related imports and calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->