### PR TITLE
refactor!: remove catalog handler and related code

### DIFF
--- a/packages/addon/src/manifest.ts
+++ b/packages/addon/src/manifest.ts
@@ -1,15 +1,7 @@
-import { Manifest, ManifestCatalog, ContentType } from 'stremio-addon-sdk';
+import { Manifest, ContentType } from 'stremio-addon-sdk';
 import { translations, DEFAULT_LANGUAGE } from './i18n';
 
 import { version, description } from '../../../package.json';
-
-// Prepare catalog structure
-export const catalog: ManifestCatalog = {
-  id: 'easynews-plus-plus',
-  name: 'Easynews++',
-  type: 'tv' as ContentType,
-  extra: [{ name: 'search', isRequired: true }],
-};
 
 // Get the English translations for the initial setup
 const englishTranslations = translations[DEFAULT_LANGUAGE];
@@ -76,13 +68,9 @@ export const manifest: Manifest = {
   id: 'community.easynews-plus-plus',
   version,
   description,
-  catalogs: [catalog],
-  resources: [
-    'catalog',
-    { name: 'meta', types: ['tv'], idPrefixes: [catalog.id] },
-    { name: 'stream', types: ['movie', 'series'], idPrefixes: ['tt'] },
-  ],
-  types: ['movie', 'series', 'tv'],
+  catalogs: [],
+  resources: [{ name: 'stream', types: ['movie', 'series'], idPrefixes: ['tt'] }],
+  types: ['movie', 'series'],
   name: 'Easynews++',
   background: 'https://i.imgur.com/QPPXf5T.jpeg',
   logo: 'https://pbs.twimg.com/profile_images/479627852757733376/8v9zH7Yo_400x400.jpeg',


### PR DESCRIPTION
resolves #66 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed catalog and metadata browsing features from the addon, limiting available resources to streaming for movies and series only.
	- Cleaned up imports and removed unused code and commented lines to streamline the codebase.

- **Chores**
	- Updated the addon manifest to reflect the removal of catalog and meta endpoints, now supporting only streaming for movies and series.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->