### PR TITLE
feat: add additional audio language options

### DIFF
--- a/packages/addon/src/custom-template.ts
+++ b/packages/addon/src/custom-template.ts
@@ -90,52 +90,19 @@ function landingTemplate(manifest: Manifest): string {
     } else if (field.key === 'maxFileSize' && translations.form.maxFileSize) {
       return { ...field, title: translations.form.maxFileSize };
     } else if (field.key === 'preferredLanguage' && translations.form.preferredLanguage) {
-      // For language selection field, translate both title and options
+      // For language selection field, translate the title and the "No preference" option
       const translatedOptions: Record<string, string> = {};
       if (field.options) {
-        // Safely access options and translations
-        if (field.options[''] !== undefined && translations.languages?.noPreference) {
-          translatedOptions[''] = translations.languages.noPreference;
-        }
-        if (field.options['eng'] !== undefined && translations.languages?.english) {
-          translatedOptions['eng'] = translations.languages.english;
-        }
-        if (field.options['ger'] !== undefined && translations.languages?.german) {
-          translatedOptions['ger'] = translations.languages.german;
-        }
-        if (field.options['spa'] !== undefined && translations.languages?.spanish) {
-          translatedOptions['spa'] = translations.languages.spanish;
-        }
-        if (field.options['fre'] !== undefined && translations.languages?.french) {
-          translatedOptions['fre'] = translations.languages.french;
-        }
-        if (field.options['ita'] !== undefined && translations.languages?.italian) {
-          translatedOptions['ita'] = translations.languages.italian;
-        }
-        if (field.options['jpn'] !== undefined && translations.languages?.japanese) {
-          translatedOptions['jpn'] = translations.languages.japanese;
-        }
-        if (field.options['por'] !== undefined && translations.languages?.portuguese) {
-          translatedOptions['por'] = translations.languages.portuguese;
-        }
-        if (field.options['rus'] !== undefined && translations.languages?.russian) {
-          translatedOptions['rus'] = translations.languages.russian;
-        }
-        if (field.options['kor'] !== undefined && translations.languages?.korean) {
-          translatedOptions['kor'] = translations.languages.korean;
-        }
-        if (field.options['chi'] !== undefined && translations.languages?.chinese) {
-          translatedOptions['chi'] = translations.languages.chinese;
-        }
-        if (field.options['dut'] !== undefined && translations.languages?.dutch) {
-          translatedOptions['dut'] = translations.languages.dutch;
-        }
-        if (field.options['rum'] !== undefined && translations.languages?.romanian) {
-          translatedOptions['rum'] = translations.languages.romanian;
-        }
-        if (field.options['bul'] !== undefined && translations.languages?.bulgarian) {
-          translatedOptions['bul'] = translations.languages.bulgarian;
-        }
+        // Handle empty key ("No preference") specially
+        Object.entries(field.options).forEach(([key, value]) => {
+          if (key === '' && translations.languages.noPreference) {
+            // Translate "No preference"
+            translatedOptions[key] = translations.languages.noPreference;
+          } else {
+            // Keep other options as is
+            translatedOptions[key] = value as string;
+          }
+        });
       }
       return {
         ...field,

--- a/packages/addon/src/i18n/index.ts
+++ b/packages/addon/src/i18n/index.ts
@@ -61,6 +61,7 @@ type TranslationKeys = {
     dutch: string;
     romanian: string;
     bulgarian: string;
+    // Note: Additional languages are defined only in the manifest for preferred audio language selection
   };
   // Sorting options
   sortingOptions: {

--- a/packages/addon/src/manifest.ts
+++ b/packages/addon/src/manifest.ts
@@ -9,6 +9,7 @@ const englishTranslations = translations[DEFAULT_LANGUAGE];
 // Language options for the preferred language selector
 const languageOptions = {
   '': englishTranslations.languages.noPreference,
+  // Core languages with UI translations
   eng: englishTranslations.languages.english,
   ger: englishTranslations.languages.german,
   spa: englishTranslations.languages.spanish,
@@ -22,6 +23,26 @@ const languageOptions = {
   dut: englishTranslations.languages.dutch,
   rum: englishTranslations.languages.romanian,
   bul: englishTranslations.languages.bulgarian,
+  // Additional language options for audio selection (without UI translations)
+  ara: 'Arabic (العربية)',
+  cze: 'Czech (Čeština)',
+  dan: 'Danish (Dansk)',
+  fin: 'Finnish (Suomi)',
+  gre: 'Greek (Ελληνικά)',
+  heb: 'Hebrew (עברית)',
+  hin: 'Hindi (हिन्दी)',
+  hun: 'Hungarian (Magyar)',
+  ice: 'Icelandic (Íslenska)',
+  ind: 'Indonesian (Bahasa Indonesia)',
+  may: 'Malay (Bahasa Melayu)',
+  nor: 'Norwegian (Norsk)',
+  per: 'Persian (فارسی)',
+  pol: 'Polish (Polski)',
+  swe: 'Swedish (Svenska)',
+  tha: 'Thai (ไทย)',
+  tur: 'Turkish (Türkçe)',
+  ukr: 'Ukrainian (Українська)',
+  vie: 'Vietnamese (Tiếng Việt)',
 } as any;
 
 // Sorting preference options


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved translation handling for language selection, now translating only the "No preference" option in the language dropdown.
  - Expanded the list of available audio language options with additional native language names for selection.
- **Documentation**
  - Added and clarified comments regarding language options and translation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->