### PR TITLE
feat: add stream URL resolver

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Base URL of the running addon (used for /resolve streaming)
+BASE_URL=https://en.pantelx.com
+
 # Port configuration
 PORT=1337
 

--- a/README.md
+++ b/README.md
@@ -271,22 +271,24 @@ Easynews is a premium Usenet provider offering a web-based Usenet browser. It en
 
 You can configure the addon server using environment variables:
 
-1. **Port Configuration**: Change the default port (1337) by setting the `PORT` environment variable
-2. **Logging Level**: Adjust the verbosity of logs with the `EASYNEWS_LOG_LEVEL` variable
+1. **Base URL Configuration**: Change the default base URL (https://en.pantelx.com) by setting the `BASE_URL` environment variable
+   - Without this, the addon falls back to http://localhost:${PORT} to resolve stream links
+3. **Port Configuration**: Change the default port (1337) by setting the `PORT` environment variable
+4. **Logging Level**: Adjust the verbosity of logs with the `EASYNEWS_LOG_LEVEL` variable
    - Options: `error`, `warn`, `info`, `debug`, `silly`, `silent`
    - Set to `debug` or `silly` for verbose logging during troubleshooting
    - Default: `info`
-3. **Log Summarization**: Control debug log grouping with `EASYNEWS_SUMMARIZE_LOGS`
+5. **Log Summarization**: Control debug log grouping with `EASYNEWS_SUMMARIZE_LOGS`
    - Set to `false` to see all individual debug logs (useful for detailed troubleshooting)
    - Set to `true` to group similar debug logs and reduce log volume
    - Default: `true` (enabled)
    - Note: This feature is not available in the Cloudflare Worker deployment
-4. **API Search Configuration**:
+6. **API Search Configuration**:
    - `TOTAL_MAX_RESULTS`: Maximum total results to return
    - `MAX_PAGES`: Maximum number of pages to search
    - `MAX_RESULTS_PER_PAGE`: Maximum results per page
    - `CACHE_TTL`: Cache time-to-live in hours
-5. **TMDB Integration**:
+7. **TMDB Integration**:
    - `TMDB_API_KEY`: TMDB API key for translated title search
 
 The easiest way to configure these settings is by copying the `.env.example` file to `.env` in the project root.

--- a/packages/addon/follow-redirects.d.ts
+++ b/packages/addon/follow-redirects.d.ts
@@ -1,0 +1,36 @@
+declare module 'follow-redirects' {
+  /**
+   * A drop-in replacement for Node’s http/https with built-in redirect support.
+   * The final `responseUrl` is exposed on the IncomingMessage.
+   */
+  export const http: {
+    // Three-arg overload: (url, options, callback) for request
+    request(
+      url: string | import('url').URL,
+      options: import('http').RequestOptions & { maxRedirects?: number },
+      callback?: (res: import('http').IncomingMessage & { responseUrl?: string }) => void
+    ): import('http').ClientRequest;
+
+    // Two-arg overload: (url, options, callback) for request
+    request(
+      options: import('http').RequestOptions & { maxRedirects?: number },
+      callback?: (res: import('http').IncomingMessage & { responseUrl?: string }) => void
+    ): import('http').ClientRequest;
+
+    // Three-arg overload: (url, options, callback) for get
+    get(
+      url: string | import('url').URL,
+      options: import('http').RequestOptions & { maxRedirects?: number },
+      callback?: (res: import('http').IncomingMessage & { responseUrl?: string }) => void
+    ): import('http').ClientRequest;
+
+    // Two-arg overload: (url, options, callback) for get
+    get(
+      options: import('http').RequestOptions & { maxRedirects?: number },
+      callback?: (res: import('http').IncomingMessage & { responseUrl?: string }) => void
+    ): import('http').ClientRequest;
+  };
+
+  // Same API over HTTPS
+  export const https: typeof http;
+}

--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -20,6 +20,7 @@
     "easynews-plus-plus-api": "file:../api",
     "easynews-plus-plus-shared": "file:../shared",
     "parse-torrent-title": "^1.4.0",
-    "stremio-addon-sdk": "^1.6.10"
+    "stremio-addon-sdk": "^1.6.10",
+    "axios": "^1.5.0"
   }
 }

--- a/packages/addon/src/addon.ts
+++ b/packages/addon/src/addon.ts
@@ -68,7 +68,6 @@ const DEFAULT_CONFIG = {
   showQualities: '4k,1080p,720p,480p',
   maxResultsPerQuality: '0',
   maxFileSize: '0',
-  baseUrl: `http://localhost:1337`,
 };
 
 const builder = new addonBuilder(manifest);
@@ -143,7 +142,7 @@ builder.defineStreamHandler(
       showQualities = DEFAULT_CONFIG.showQualities,
       maxResultsPerQuality = DEFAULT_CONFIG.maxResultsPerQuality,
       maxFileSize = DEFAULT_CONFIG.maxFileSize,
-      baseUrl = DEFAULT_CONFIG.baseUrl,
+      baseUrl,
       ...options
     } = config;
 

--- a/packages/addon/src/addon.ts
+++ b/packages/addon/src/addon.ts
@@ -556,7 +556,12 @@ builder.defineStreamHandler(
               duration: getDuration(file),
               size: getSize(file),
               title,
-              url: `${createStreamUrl(res, username, password)}/${createStreamPath(file)}`,
+              url: createStreamUrl(
+                { downURL: res.downURL, dlFarm: res.dlFarm, dlPort: res.dlPort },
+                username,
+                password,
+                createStreamPath(file)
+              ),
               videoSize: file.rawSize,
               file,
               preferredLang,

--- a/packages/addon/src/server.ts
+++ b/packages/addon/src/server.ts
@@ -236,7 +236,6 @@ logger.info('--- Environment configuration ---');
 logger.info(`PORT: ${process.env.PORT || 'undefined'}`);
 logger.info(`LOG_LEVEL: ${logger.level || 'undefined'}`);
 logger.info(`VERSION: ${getVersion() || 'undefined'}`);
-logger.info(`BASE_URL: ${process.env.BASE_URL || 'undefined'}`);
 
 // Log API search configuration
 logger.info('--- API search configuration ---');

--- a/packages/addon/src/server.ts
+++ b/packages/addon/src/server.ts
@@ -114,6 +114,13 @@ function serveHTTP(addonInterface: AddonInterface, opts: ServerOptions = {}) {
         return;
       }
       
+      // Only accept Base64-URL with hostname easynews.com
+      const host = parsed.hostname.toLowerCase();
+      if (!host.endsWith('easynews.com')) {
+        res.status(403).send('Domain not allowed');
+        return;
+      }
+      
       // Extract and remove credentials
       const parsed = new URL(targetUrl);
       const username = parsed.searchParams.get('u') || '';

--- a/packages/addon/src/server.ts
+++ b/packages/addon/src/server.ts
@@ -94,7 +94,7 @@ function serveHTTP(addonInterface: AddonInterface, opts: ServerOptions = {}) {
     }
   });
 
-  // Proxy endpoint for stream requests
+  // Resolve endpoint for stream requests
   app.get(
     '/resolve',
     async (req: Request, res: Response, next: NextFunction): Promise<void> => {
@@ -114,7 +114,8 @@ function serveHTTP(addonInterface: AddonInterface, opts: ServerOptions = {}) {
         return;
       }
       
-      // Only accept Base64-URL with hostname easynews.com
+      // Only accept hosts under easynews.com
+      const parsed = new URL(targetUrl);
       const host = parsed.hostname.toLowerCase();
       if (!host.endsWith('easynews.com')) {
         res.status(403).send('Domain not allowed');
@@ -122,7 +123,6 @@ function serveHTTP(addonInterface: AddonInterface, opts: ServerOptions = {}) {
       }
       
       // Extract and remove credentials
-      const parsed = new URL(targetUrl);
       const username = parsed.searchParams.get('u') || '';
       const password = parsed.searchParams.get('p') || '';
       parsed.searchParams.delete('u');

--- a/packages/addon/src/server.ts
+++ b/packages/addon/src/server.ts
@@ -1,7 +1,8 @@
 import express, { Request, Response, NextFunction } from 'express';
 import { AddonInterface } from 'stremio-addon-sdk';
-import axios from 'axios';
 import { Buffer } from 'buffer';
+import { http, https } from 'follow-redirects';
+import { IncomingMessage } from 'http';
 import path from 'path';
 // Import getRouter manually since TypeScript definitions are incomplete
 // @ts-ignore
@@ -93,73 +94,68 @@ function serveHTTP(addonInterface: AddonInterface, opts: ServerOptions = {}) {
       res.end(landingHTML);
     }
   });
-
+  
   // Resolve endpoint for stream requests
-  app.get(
-    '/resolve',
-    async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-      // Expect a base64-encoded URL in the `url` query parameter
-      const encoded = req.query.url as string;
-      if (!encoded) {
-        res.status(400).send('Missing url parameter');
-        return;
-      }
-      
-      let targetUrl: string;
-      try {
-        // Decode the Base64 payload back into the Easynews URL with credentials as query-params
-        targetUrl = Buffer.from(encoded, 'base64').toString('utf-8');
-      } catch {
-        res.status(400).send('Invalid url encoding');
-        return;
-      }
-      
-      // Only accept hosts under easynews.com
-      const parsed = new URL(targetUrl);
-      const host = parsed.hostname.toLowerCase();
-      if (!host.endsWith('easynews.com')) {
-        res.status(403).send('Domain not allowed');
-        return;
-      }
-      
-      // Extract and remove credentials
-      const username = parsed.searchParams.get('u') || '';
-      const password = parsed.searchParams.get('p') || '';
-      parsed.searchParams.delete('u');
-      parsed.searchParams.delete('p');
-      const cleanUrl = parsed.toString();
-      
-      try {
-        // Perform a GET that follows redirects to the final URL (we only need headers)
-        const upstream = await axios.get(cleanUrl, {
-          auth: { username, password },
-          maxRedirects: 1,                // the final URL is provided in the first redirect
-          validateStatus: () => true,     // accept 3xx and 2xx
-          responseType: 'stream'          // stream so we don't buffer the body
-            });
-        
-        // Axios/FOLLOW-REDIRECTS attaches the final URL to:
-        const finalUrl =
-          // @ts-ignore
-          upstream.request?.res?.responseUrl ||
-          // fallback for older versions
-          (upstream.request as any)?._redirectable?._currentUrl ||
-          cleanUrl;
-        
-        if (!finalUrl) {
-          res.status(502).send('Could not determine final URL');
-          return;
-        }
-        
-        // Redirect the client to the real CDN URL
-        res.redirect(307, finalUrl);
-      } catch (err) {
-        console.error(`Error resolving final URL from ${cleanUrl}:`, err);
-        res.status(502).send('Error resolving stream');
-      }
+  app.get('/resolve', (req: Request, res: Response) => {
+    // Expect a base64-encoded URL in the `url` query parameter
+    const encoded = req.query.url as string;
+    if (!encoded) {
+      res.status(400).send('Missing url parameter');
+      return;
     }
-  );
+    
+    let targetUrl: string;
+    try {
+      // Decode the Base64 payload back into the Easynews URL with credentials as query-params
+      targetUrl = Buffer.from(encoded, 'base64').toString('utf-8');
+    } catch {
+      res.status(400).send('Invalid url encoding');
+      return;
+    }
 
+    // Only accept hosts under easynews.com
+    const parsed = new URL(targetUrl);
+    const host = parsed.hostname.toLowerCase();
+    if (!host.endsWith('easynews.com')) {
+      res.status(403).send('Domain not allowed');
+      return;
+    }
+
+    // Extract and remove credentials
+    const username = parsed.searchParams.get('u') || '';
+    const password = parsed.searchParams.get('p') || '';
+    parsed.searchParams.delete('u');
+    parsed.searchParams.delete('p');
+    const cleanUrl = parsed.toString();
+
+    // Choose the correct client
+    const client = cleanUrl.startsWith('https:') ? https : http;
+    
+    // HEAD-only request to follow redirects and get final URL  
+    const request = client.request(
+      cleanUrl,
+      {
+        method: 'HEAD',
+        headers: {
+          Authorization: 'Basic ' + Buffer.from(`${username}:${password}`).toString('base64'),
+        },
+        maxRedirects: 5,
+      },
+      // Redirect the client to the real CDN URL
+      (upstream: IncomingMessage & { responseUrl?: string }) => {
+        const finalUrl = upstream.responseUrl || cleanUrl;
+        res.redirect(307, finalUrl);
+      }
+    );
+    
+    request.on('error', (err: Error) => {
+      console.error(`Error resolving stream ${cleanUrl}:`, err);
+      res.status(502).send('Error resolving stream');
+    });
+    
+    request.end();
+  });
+ 
   if (hasConfig)
     app.get('/configure', (req: Request, res: Response) => {
       // Set no-cache headers

--- a/packages/addon/src/utils.ts
+++ b/packages/addon/src/utils.ts
@@ -344,7 +344,7 @@ export function createStreamUrl(
   const encoded = Buffer.from(authUrl).toString('base64');
   const base = process.env.BASE_URL || `http://localhost:${process.env.PORT}`;
   logger.debug(
-    `Stream URL created: ${base}/resolve?url=${encoded}`
+    `Stream URL created: ${base}/resolve?url=<encoded-easynews-url>`
   );
   return `${base}/resolve?url=${encoded}`;
 }

--- a/packages/addon/src/utils.ts
+++ b/packages/addon/src/utils.ts
@@ -5,6 +5,7 @@ import { parse as parseTorrentTitle } from 'parse-torrent-title';
 import path from 'path';
 import dotenv from 'dotenv';
 import { createLogger } from 'easynews-plus-plus-shared';
+import { Buffer } from 'buffer';
 
 // Import the custom titles JSON directly
 import customTitlesJson from '../../../custom-titles.json';
@@ -325,19 +326,27 @@ export function matchesTitle(title: string, query: string, strict: boolean) {
   return allWordsMatch;
 }
 
+/**
+ * Create a stream URL that always routes through the addon's /resolve endpoint.
+ */
 export function createStreamUrl(
   { downURL, dlFarm, dlPort }: Pick<EasynewsSearchResponse, 'downURL' | 'dlFarm' | 'dlPort'>,
   username: string,
-  password: string
-) {
+  password: string,
+  filePath: string
+): string {
   logger.debug(`Creating stream URL with farm: ${dlFarm}, port: ${dlPort}`);
-  // For streaming, we can still use the username:password@ format in the URL
-  // as it will be handled by media players, not the fetch API
-  const url = `${downURL.replace('https://', `https://${username}:${password}@`)}/${dlFarm}/${dlPort}`;
+  // Base URL without embedded credentials
+  const directUrl = `${downURL}/${dlFarm}/${dlPort}/${filePath}`;
+  // Credentials as query‐parameters
+  const authUrl = `${directUrl}?u=${encodeURIComponent(username)}&p=${encodeURIComponent(password)}`;
+  // Base64-encode and via BASE_URL (or fallback to localhost + PORT) /resolve endpoint
+  const encoded = Buffer.from(authUrl).toString('base64');
+  const base = process.env.BASE_URL || `http://localhost:${process.env.PORT}`;
   logger.debug(
-    `Stream URL created: ${url.substring(0, url.indexOf('@') + 1)}***/${dlFarm}/${dlPort}`
+    `Stream URL created: ${base}/resolve?url=${encoded}`
   );
-  return url;
+  return `${base}/resolve?url=${encoded}`;
 }
 
 export function createStreamPath(file: FileData) {

--- a/packages/addon/src/utils.ts
+++ b/packages/addon/src/utils.ts
@@ -334,21 +334,30 @@ export function createStreamUrl(
   username: string,
   password: string,
   filePath: string,
-  baseUrl: string
+  baseUrl?: string
 ): string {
   logger.debug(`Creating stream URL with farm: ${dlFarm}, port: ${dlPort}`);
-  // Direct URL without embedded credentials
-  const directUrl = `${downURL}/${dlFarm}/${dlPort}/${filePath}`;
-  // Credentials as query‐parameters
-  const authUrl = `${directUrl}?u=${encodeURIComponent(username)}&p=${encodeURIComponent(password)}`;
-  // Base64-encode /resolve endpoint
-  const encoded = Buffer.from(authUrl).toString('base64');
-  // Strip any trailing slash on baseUrl before concatenating
-  const normalizedBase = baseUrl.replace(/\/+$/, '');
-  logger.debug(
-    `Stream URL created: ${normalizedBase}/resolve?url=<encoded-easynews-url>`
-  );
-  return `${normalizedBase}/resolve?url=${encoded}`;
+  if (!baseUrl) {
+    // Legacy mode: credentials in URL
+    const url = `${downURL.replace('https://', `https://${username}:${password}@`)}/${dlFarm}/${dlPort}/${filePath}`;
+    logger.debug(
+      `Stream URL created: ${url.substring(0, url.indexOf('@') + 1)}***/${dlFarm}/${dlPort}/${filePath}`
+    );
+    return url;
+  } else {
+    // Resolve mode: route via addon
+    const url = `${downURL}/${dlFarm}/${dlPort}/${filePath}`;
+    // Credentials as query‐parameters
+    const authUrl = `${url}?u=${encodeURIComponent(username)}&p=${encodeURIComponent(password)}`;
+    // Base64-encode /resolve endpoint
+    const encoded = Buffer.from(authUrl).toString('base64');
+    // Strip any trailing slash on baseUrl before concatenating
+    const normalizedBase = baseUrl.replace(/\/+$/, '');
+    logger.debug(
+      `Stream URL created: ${normalizedBase}/resolve?url=<encoded-easynews-url>`
+    );
+    return `${normalizedBase}/resolve?url=${encoded}`;
+  }
 }
 
 export function createStreamPath(file: FileData) {

--- a/packages/addon/tsconfig.json
+++ b/packages/addon/tsconfig.json
@@ -7,7 +7,7 @@
     "composite": true,
     "declaration": true
   },
-  "include": ["src/**/*", "stremio-addon-sdk-builder.d.ts", "stremio-addon-sdk.d.ts"],
+  "include": ["src/**/*", "stremio-addon-sdk-builder.d.ts", "stremio-addon-sdk.d.ts", "follow-redirects.d.ts"],
   "exclude": ["**/*.test.ts"],
   "references": [
     {


### PR DESCRIPTION
Enable stream resolution via /resolve endpoint to hand out the final, public stream URL. This resolver preserves byte‐range requests for seamless playback and ensures all subsequent media data flows directly from the EasyNews CDN.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new endpoint to resolve and redirect streaming URLs securely, improving privacy by removing embedded credentials from URLs.
  - Introduced support for a configurable base URL in both server and client configurations.

- **Improvements**
  - Streaming URLs now use a new format that encodes credentials as query parameters and routes them through the new resolver endpoint for enhanced security.
  - Updated client-side scripts to automatically set the base URL based on the current page origin.

- **Dependency Updates**
  - Added the `axios` library as a dependency.

- **TypeScript & Developer Experience**
  - Added TypeScript declarations for the `follow-redirects` module to improve type safety.
  - Updated TypeScript configuration to include new declaration files.

- **Chores**
  - Minor update to the example environment file formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->