### PR TITLE
feat: add stream URL resolver

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Base URL of the running addon (used for /resolve streaming)
+BASE_URL=https://en.pantelx.com
+
 # Port configuration
 PORT=1337
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,5 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'daily'
-    open-pull-requests-limit: 10
+      interval: 'weekly'
+  #   open-pull-requests-limit: 10

--- a/README.md
+++ b/README.md
@@ -111,12 +111,12 @@
   - Web (Browser)
   - Android Mobile (beta)
   - iOS (Web & TestFlight)
+  - Android TV
 
 #### ⚠️ **Partially Supported or Untested:**
 
 - Stremio:
   - macOS (there may be issues with the internal player)
-  - Android TV
   - Android Mobile (stable)
   - Steam Deck
   - Raspberry Pi

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@
 
 - Stremio:
   - macOS (there may be issues with the internal player)
-  - Android TV (when using a different player than ExoPlayer)
+  - Android TV
   - Android Mobile (stable)
   - Steam Deck
   - Raspberry Pi
@@ -128,7 +128,6 @@
 
 - Stremio:
   - webOS
-  - Android TV (when using ExoPlayer (NVIDIA Shield, Onn Pro 4K, Chromecast 4K))
 
 > [!NOTE]  
 > We are actively working on expanding platform support. If you encounter any issues with a specific platform, please report them in our [Discord community](https://discord.gg/Ma4SnagqwE) or create a new issue on GitHub.

--- a/README.md
+++ b/README.md
@@ -271,22 +271,24 @@ Easynews is a premium Usenet provider offering a web-based Usenet browser. It en
 
 You can configure the addon server using environment variables:
 
-1. **Port Configuration**: Change the default port (1337) by setting the `PORT` environment variable
-2. **Logging Level**: Adjust the verbosity of logs with the `EASYNEWS_LOG_LEVEL` variable
+1. **Base URL Configuration**: Change the default base URL (https://en.pantelx.com) by setting the `BASE_URL` environment variable
+   - Without this, the addon falls back to http://localhost:${PORT} to resolve stream links
+3. **Port Configuration**: Change the default port (1337) by setting the `PORT` environment variable
+4. **Logging Level**: Adjust the verbosity of logs with the `EASYNEWS_LOG_LEVEL` variable
    - Options: `error`, `warn`, `info`, `debug`, `silly`, `silent`
    - Set to `debug` or `silly` for verbose logging during troubleshooting
    - Default: `info`
-3. **Log Summarization**: Control debug log grouping with `EASYNEWS_SUMMARIZE_LOGS`
+5. **Log Summarization**: Control debug log grouping with `EASYNEWS_SUMMARIZE_LOGS`
    - Set to `false` to see all individual debug logs (useful for detailed troubleshooting)
    - Set to `true` to group similar debug logs and reduce log volume
    - Default: `true` (enabled)
    - Note: This feature is not available in the Cloudflare Worker deployment
-4. **API Search Configuration**:
+6. **API Search Configuration**:
    - `TOTAL_MAX_RESULTS`: Maximum total results to return
    - `MAX_PAGES`: Maximum number of pages to search
    - `MAX_RESULTS_PER_PAGE`: Maximum results per page
    - `CACHE_TTL`: Cache time-to-live in hours
-5. **TMDB Integration**:
+7. **TMDB Integration**:
    - `TMDB_API_KEY`: TMDB API key for translated title search
 
 The easiest way to configure these settings is by copying the `.env.example` file to `.env` in the project root.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5656,9 +5656,9 @@
       }
     },
     "node_modules/wrangler": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.14.1.tgz",
-      "integrity": "sha512-EU7IThP7i68TBftJJSveogvWZ5k/WRijcJh3UclDWiWWhDZTPbL6LOJEFhHKqFzHOaC4Y2Aewt48rfTz0e7oCw==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.14.2.tgz",
+      "integrity": "sha512-kD0ilA7WXwhDt1lfyPwppZ2/lT9uwDLp93tfqnqrUENmP/uj+5tErzfZY51emtgXZoU1HFK6HytBEYLRCvCiPg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -5981,7 +5981,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250505.0",
-        "wrangler": "^4.14.1"
+        "wrangler": "^4.14.2"
       }
     },
     "packages/shared": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -160,9 +160,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20250428.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250428.0.tgz",
-      "integrity": "sha512-6nVe9oV4Hdec6ctzMtW80TiDvNTd2oFPi3VsKqSDVaJSJbL+4b6seyJ7G/UEPI+si6JhHBSLV2/9lNXNGLjClA==",
+      "version": "1.20250507.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250507.0.tgz",
+      "integrity": "sha512-xC+8hmQuOUUNCVT9DWpLMfxhR4Xs4kI8v7Bkybh4pzGC85moH6fMfCBNaP0YQCNAA/BR56aL/AwfvMVGskTK/A==",
       "cpu": [
         "x64"
       ],
@@ -177,9 +177,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20250428.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250428.0.tgz",
-      "integrity": "sha512-/TB7bh7SIJ5f+6r4PHsAz7+9Qal/TK1cJuKFkUno1kqGlZbdrMwH0ATYwlWC/nBFeu2FB3NUolsTntEuy23hnQ==",
+      "version": "1.20250507.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250507.0.tgz",
+      "integrity": "sha512-Oynff5H8yM4trfUFaKdkOvPV3jac8mg7QC19ILZluCVgLx/JGEVLEJ7do1Na9rLqV8CK4gmUXPrUMX7uerhQgg==",
       "cpu": [
         "arm64"
       ],
@@ -194,9 +194,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20250428.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250428.0.tgz",
-      "integrity": "sha512-9eCbj+R3CKqpiXP6DfAA20DxKge+OTj7Hyw3ZewiEhWH9INIHiJwJQYybu4iq9kJEGjnGvxgguLFjSCWm26hgg==",
+      "version": "1.20250507.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250507.0.tgz",
+      "integrity": "sha512-/HAA+Zg/R7Q/Smyl835FUFKjotZN1UzN9j/BHBd0xKmKov97QkXAX8gsyGnyKqRReIOinp8x/8+UebTICR7VJw==",
       "cpu": [
         "x64"
       ],
@@ -211,9 +211,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20250428.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250428.0.tgz",
-      "integrity": "sha512-D9NRBnW46nl1EQsP13qfkYb5lbt4C6nxl38SBKY/NOcZAUoHzNB5K0GaK8LxvpkM7X/97ySojlMfR5jh5DNXYQ==",
+      "version": "1.20250507.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250507.0.tgz",
+      "integrity": "sha512-NMPibSdOYeycU0IrKkgOESFJQy7dEpHvuatZxQxlT+mIQK0INzI3irp2kKxhF99s25kPC4p+xg9bU3ugTrs3VQ==",
       "cpu": [
         "arm64"
       ],
@@ -228,9 +228,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20250428.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250428.0.tgz",
-      "integrity": "sha512-RQCRj28eitjKD0tmei6iFOuWqMuHMHdNGEigRmbkmuTlpbWHNAoHikgCzZQ/dkKDdatA76TmcpbyECNf31oaTA==",
+      "version": "1.20250507.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250507.0.tgz",
+      "integrity": "sha512-c91fhNP8ufycdIDqjVyKTqeb4ewkbAYXFQbLreMVgh4LLQQPDDEte8wCdmaFy5bIL0M9d85PpdCq51RCzq/FaQ==",
       "cpu": [
         "x64"
       ],
@@ -304,9 +304,9 @@
       "optional": true
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.2.tgz",
-      "integrity": "sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.4.tgz",
+      "integrity": "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==",
       "cpu": [
         "ppc64"
       ],
@@ -321,9 +321,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.2.tgz",
-      "integrity": "sha512-NQhH7jFstVY5x8CKbcfa166GoV0EFkaPkCKBQkdPJFvo5u+nGXLEH/ooniLb3QI8Fk58YAx7nsPLozUWfCBOJA==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.4.tgz",
+      "integrity": "sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ==",
       "cpu": [
         "arm"
       ],
@@ -338,9 +338,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.2.tgz",
-      "integrity": "sha512-5ZAX5xOmTligeBaeNEPnPaeEuah53Id2tX4c2CVP3JaROTH+j4fnfHCkr1PjXMd78hMst+TlkfKcW/DlTq0i4w==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.4.tgz",
+      "integrity": "sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==",
       "cpu": [
         "arm64"
       ],
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.2.tgz",
-      "integrity": "sha512-Ffcx+nnma8Sge4jzddPHCZVRvIfQ0kMsUsCMcJRHkGJ1cDmhe4SsrYIjLUKn1xpHZybmOqCWwB0zQvsjdEHtkg==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.4.tgz",
+      "integrity": "sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==",
       "cpu": [
         "x64"
       ],
@@ -372,9 +372,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.2.tgz",
-      "integrity": "sha512-MpM6LUVTXAzOvN4KbjzU/q5smzryuoNjlriAIx+06RpecwCkL9JpenNzpKd2YMzLJFOdPqBpuub6eVRP5IgiSA==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.4.tgz",
+      "integrity": "sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==",
       "cpu": [
         "arm64"
       ],
@@ -389,9 +389,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.2.tgz",
-      "integrity": "sha512-5eRPrTX7wFyuWe8FqEFPG2cU0+butQQVNcT4sVipqjLYQjjh8a8+vUTfgBKM88ObB85ahsnTwF7PSIt6PG+QkA==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.4.tgz",
+      "integrity": "sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==",
       "cpu": [
         "x64"
       ],
@@ -406,9 +406,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.2.tgz",
-      "integrity": "sha512-mLwm4vXKiQ2UTSX4+ImyiPdiHjiZhIaE9QvC7sw0tZ6HoNMjYAqQpGyui5VRIi5sGd+uWq940gdCbY3VLvsO1w==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.4.tgz",
+      "integrity": "sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==",
       "cpu": [
         "arm64"
       ],
@@ -423,9 +423,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.2.tgz",
-      "integrity": "sha512-6qyyn6TjayJSwGpm8J9QYYGQcRgc90nmfdUb0O7pp1s4lTY+9D0H9O02v5JqGApUyiHOtkz6+1hZNvNtEhbwRQ==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.4.tgz",
+      "integrity": "sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==",
       "cpu": [
         "x64"
       ],
@@ -440,9 +440,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.2.tgz",
-      "integrity": "sha512-UHBRgJcmjJv5oeQF8EpTRZs/1knq6loLxTsjc3nxO9eXAPDLcWW55flrMVc97qFPbmZP31ta1AZVUKQzKTzb0g==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.4.tgz",
+      "integrity": "sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==",
       "cpu": [
         "arm"
       ],
@@ -457,9 +457,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.2.tgz",
-      "integrity": "sha512-gq/sjLsOyMT19I8obBISvhoYiZIAaGF8JpeXu1u8yPv8BE5HlWYobmlsfijFIZ9hIVGYkbdFhEqC0NvM4kNO0g==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.4.tgz",
+      "integrity": "sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==",
       "cpu": [
         "arm64"
       ],
@@ -474,9 +474,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.2.tgz",
-      "integrity": "sha512-bBYCv9obgW2cBP+2ZWfjYTU+f5cxRoGGQ5SeDbYdFCAZpYWrfjjfYwvUpP8MlKbP0nwZ5gyOU/0aUzZ5HWPuvQ==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.4.tgz",
+      "integrity": "sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==",
       "cpu": [
         "ia32"
       ],
@@ -491,9 +491,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.2.tgz",
-      "integrity": "sha512-SHNGiKtvnU2dBlM5D8CXRFdd+6etgZ9dXfaPCeJtz+37PIUlixvlIhI23L5khKXs3DIzAn9V8v+qb1TRKrgT5w==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.4.tgz",
+      "integrity": "sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==",
       "cpu": [
         "loong64"
       ],
@@ -508,9 +508,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.2.tgz",
-      "integrity": "sha512-hDDRlzE6rPeoj+5fsADqdUZl1OzqDYow4TB4Y/3PlKBD0ph1e6uPHzIQcv2Z65u2K0kpeByIyAjCmjn1hJgG0Q==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.4.tgz",
+      "integrity": "sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==",
       "cpu": [
         "mips64el"
       ],
@@ -525,9 +525,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.2.tgz",
-      "integrity": "sha512-tsHu2RRSWzipmUi9UBDEzc0nLc4HtpZEI5Ba+Omms5456x5WaNuiG3u7xh5AO6sipnJ9r4cRWQB2tUjPyIkc6g==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.4.tgz",
+      "integrity": "sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==",
       "cpu": [
         "ppc64"
       ],
@@ -542,9 +542,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.2.tgz",
-      "integrity": "sha512-k4LtpgV7NJQOml/10uPU0s4SAXGnowi5qBSjaLWMojNCUICNu7TshqHLAEbkBdAszL5TabfvQ48kK84hyFzjnw==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.4.tgz",
+      "integrity": "sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==",
       "cpu": [
         "riscv64"
       ],
@@ -559,9 +559,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.2.tgz",
-      "integrity": "sha512-GRa4IshOdvKY7M/rDpRR3gkiTNp34M0eLTaC1a08gNrh4u488aPhuZOCpkF6+2wl3zAN7L7XIpOFBhnaE3/Q8Q==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.4.tgz",
+      "integrity": "sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==",
       "cpu": [
         "s390x"
       ],
@@ -576,9 +576,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.2.tgz",
-      "integrity": "sha512-QInHERlqpTTZ4FRB0fROQWXcYRD64lAoiegezDunLpalZMjcUcld3YzZmVJ2H/Cp0wJRZ8Xtjtj0cEHhYc/uUg==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.4.tgz",
+      "integrity": "sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==",
       "cpu": [
         "x64"
       ],
@@ -593,9 +593,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.2.tgz",
-      "integrity": "sha512-talAIBoY5M8vHc6EeI2WW9d/CkiO9MQJ0IOWX8hrLhxGbro/vBXJvaQXefW2cP0z0nQVTdQ/eNyGFV1GSKrxfw==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.4.tgz",
+      "integrity": "sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==",
       "cpu": [
         "arm64"
       ],
@@ -610,9 +610,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.2.tgz",
-      "integrity": "sha512-voZT9Z+tpOxrvfKFyfDYPc4DO4rk06qamv1a/fkuzHpiVBMOhpjK+vBmWM8J1eiB3OLSMFYNaOaBNLXGChf5tg==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.4.tgz",
+      "integrity": "sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==",
       "cpu": [
         "x64"
       ],
@@ -627,9 +627,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.2.tgz",
-      "integrity": "sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.4.tgz",
+      "integrity": "sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==",
       "cpu": [
         "arm64"
       ],
@@ -644,9 +644,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.2.tgz",
-      "integrity": "sha512-t/TkWwahkH0Tsgoq1Ju7QfgGhArkGLkF1uYz8nQS/PPFlXbP5YgRpqQR3ARRiC2iXoLTWFxc6DJMSK10dVXluw==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.4.tgz",
+      "integrity": "sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw==",
       "cpu": [
         "x64"
       ],
@@ -661,9 +661,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.2.tgz",
-      "integrity": "sha512-cfZH1co2+imVdWCjd+D1gf9NjkchVhhdpgb1q5y6Hcv9TP6Zi9ZG/beI3ig8TvwT9lH9dlxLq5MQBBgwuj4xvA==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.4.tgz",
+      "integrity": "sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==",
       "cpu": [
         "x64"
       ],
@@ -678,9 +678,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.2.tgz",
-      "integrity": "sha512-7Loyjh+D/Nx/sOTzV8vfbB3GJuHdOQyrOryFdZvPHLf42Tk9ivBU5Aedi7iyX+x6rbn2Mh68T4qq1SDqJBQO5Q==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.4.tgz",
+      "integrity": "sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==",
       "cpu": [
         "arm64"
       ],
@@ -695,9 +695,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.2.tgz",
-      "integrity": "sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.4.tgz",
+      "integrity": "sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==",
       "cpu": [
         "ia32"
       ],
@@ -712,9 +712,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.2.tgz",
-      "integrity": "sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.4.tgz",
+      "integrity": "sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==",
       "cpu": [
         "x64"
       ],
@@ -2700,9 +2700,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.2.tgz",
-      "integrity": "sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.4.tgz",
+      "integrity": "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2713,31 +2713,31 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.2",
-        "@esbuild/android-arm": "0.25.2",
-        "@esbuild/android-arm64": "0.25.2",
-        "@esbuild/android-x64": "0.25.2",
-        "@esbuild/darwin-arm64": "0.25.2",
-        "@esbuild/darwin-x64": "0.25.2",
-        "@esbuild/freebsd-arm64": "0.25.2",
-        "@esbuild/freebsd-x64": "0.25.2",
-        "@esbuild/linux-arm": "0.25.2",
-        "@esbuild/linux-arm64": "0.25.2",
-        "@esbuild/linux-ia32": "0.25.2",
-        "@esbuild/linux-loong64": "0.25.2",
-        "@esbuild/linux-mips64el": "0.25.2",
-        "@esbuild/linux-ppc64": "0.25.2",
-        "@esbuild/linux-riscv64": "0.25.2",
-        "@esbuild/linux-s390x": "0.25.2",
-        "@esbuild/linux-x64": "0.25.2",
-        "@esbuild/netbsd-arm64": "0.25.2",
-        "@esbuild/netbsd-x64": "0.25.2",
-        "@esbuild/openbsd-arm64": "0.25.2",
-        "@esbuild/openbsd-x64": "0.25.2",
-        "@esbuild/sunos-x64": "0.25.2",
-        "@esbuild/win32-arm64": "0.25.2",
-        "@esbuild/win32-ia32": "0.25.2",
-        "@esbuild/win32-x64": "0.25.2"
+        "@esbuild/aix-ppc64": "0.25.4",
+        "@esbuild/android-arm": "0.25.4",
+        "@esbuild/android-arm64": "0.25.4",
+        "@esbuild/android-x64": "0.25.4",
+        "@esbuild/darwin-arm64": "0.25.4",
+        "@esbuild/darwin-x64": "0.25.4",
+        "@esbuild/freebsd-arm64": "0.25.4",
+        "@esbuild/freebsd-x64": "0.25.4",
+        "@esbuild/linux-arm": "0.25.4",
+        "@esbuild/linux-arm64": "0.25.4",
+        "@esbuild/linux-ia32": "0.25.4",
+        "@esbuild/linux-loong64": "0.25.4",
+        "@esbuild/linux-mips64el": "0.25.4",
+        "@esbuild/linux-ppc64": "0.25.4",
+        "@esbuild/linux-riscv64": "0.25.4",
+        "@esbuild/linux-s390x": "0.25.4",
+        "@esbuild/linux-x64": "0.25.4",
+        "@esbuild/netbsd-arm64": "0.25.4",
+        "@esbuild/netbsd-x64": "0.25.4",
+        "@esbuild/openbsd-arm64": "0.25.4",
+        "@esbuild/openbsd-x64": "0.25.4",
+        "@esbuild/sunos-x64": "0.25.4",
+        "@esbuild/win32-arm64": "0.25.4",
+        "@esbuild/win32-ia32": "0.25.4",
+        "@esbuild/win32-x64": "0.25.4"
       }
     },
     "node_modules/escalade": {
@@ -3663,9 +3663,9 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20250428.1",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20250428.1.tgz",
-      "integrity": "sha512-M3qcJXjeAEimHrEeWXEhrJiC3YHB5M3QSqqK67pOTI+lHn0QyVG/2iFUjVJ/nv+i10uxeAEva8GRGeu+tKRCmQ==",
+      "version": "4.20250507.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20250507.0.tgz",
+      "integrity": "sha512-EgbQRt/Hnr8HCmW2J/4LRNE3yOzJTdNd98XJ8gnGXFKcimXxUFPiWP3k1df+ZPCtEHp6cXxi8+jP7v9vuIbIsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3676,7 +3676,7 @@
         "glob-to-regexp": "0.4.1",
         "stoppable": "1.1.0",
         "undici": "^5.28.5",
-        "workerd": "1.20250428.0",
+        "workerd": "1.20250507.0",
         "ws": "8.18.0",
         "youch": "3.3.4",
         "zod": "3.22.3"
@@ -5635,9 +5635,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20250428.0",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250428.0.tgz",
-      "integrity": "sha512-JJNWkHkwPQKQdvtM9UORijgYdcdJsihA4SfYjwh02IUQsdMyZ9jizV1sX9yWi9B9ptlohTW8UNHJEATuphGgdg==",
+      "version": "1.20250507.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250507.0.tgz",
+      "integrity": "sha512-OXaGjEh5THT9iblwWIyPrYBoaPe/d4zN03Go7/w8CmS8sma7//O9hjbk43sboWkc89taGPmU0/LNyZUUiUlHeQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -5648,28 +5648,28 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20250428.0",
-        "@cloudflare/workerd-darwin-arm64": "1.20250428.0",
-        "@cloudflare/workerd-linux-64": "1.20250428.0",
-        "@cloudflare/workerd-linux-arm64": "1.20250428.0",
-        "@cloudflare/workerd-windows-64": "1.20250428.0"
+        "@cloudflare/workerd-darwin-64": "1.20250507.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20250507.0",
+        "@cloudflare/workerd-linux-64": "1.20250507.0",
+        "@cloudflare/workerd-linux-arm64": "1.20250507.0",
+        "@cloudflare/workerd-windows-64": "1.20250507.0"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.14.2.tgz",
-      "integrity": "sha512-kD0ilA7WXwhDt1lfyPwppZ2/lT9uwDLp93tfqnqrUENmP/uj+5tErzfZY51emtgXZoU1HFK6HytBEYLRCvCiPg==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.14.3.tgz",
+      "integrity": "sha512-gY2n3cC8yb8VyaM0aY9fXX5AIah+VkGefmAHltUBgVpJaM4QXun6O85BydtTEljLL67JTyFyBDn/UPyg2WhESQ==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.4.0",
         "@cloudflare/unenv-preset": "2.3.1",
         "blake3-wasm": "2.1.5",
-        "esbuild": "0.25.2",
-        "miniflare": "4.20250428.1",
+        "esbuild": "0.25.4",
+        "miniflare": "4.20250507.0",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.15",
-        "workerd": "1.20250428.0"
+        "workerd": "1.20250507.0"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
@@ -5683,7 +5683,7 @@
         "sharp": "^0.33.5"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20250428.0"
+        "@cloudflare/workers-types": "^4.20250507.0"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -5981,7 +5981,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250507.0",
-        "wrangler": "^4.14.2"
+        "wrangler": "^4.14.3"
       }
     },
     "packages/shared": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -245,9 +245,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20250505.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250505.0.tgz",
-      "integrity": "sha512-pLQ/UaCupEy3fTTfy7yCR7FuAbawvCohYAdadGHPUfzssksA9MhkqBLlzYWRwIoC34R8grVn4XOCknEg+NMr0Q==",
+      "version": "4.20250507.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250507.0.tgz",
+      "integrity": "sha512-fkrq7A6XWgPEmXJDwu9TS/Zw7qho3eGlrOlicKue32Bdul0Ma4Mym4sh7ZeGbayBXxkOx/fHpm5GfhVEtngRWQ==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -5980,7 +5980,7 @@
         "hono-stremio": "^0.1.1"
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20250505.0",
+        "@cloudflare/workers-types": "^4.20250507.0",
         "wrangler": "^4.14.2"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1704,9 +1704,9 @@
       "license": "MIT"
     },
     "node_modules/@types/stremio-addon-sdk": {
-      "version": "1.6.11",
-      "resolved": "https://registry.npmjs.org/@types/stremio-addon-sdk/-/stremio-addon-sdk-1.6.11.tgz",
-      "integrity": "sha512-y0nXwX2gqrWcVYLEvujxqLOm/yZoMu8nLyiw1MthgVuiPp6RVfgWqwpql71MUV5shSfPNsd7EtsiWw2cUFhcWQ==",
+      "version": "1.6.12",
+      "resolved": "https://registry.npmjs.org/@types/stremio-addon-sdk/-/stremio-addon-sdk-1.6.12.tgz",
+      "integrity": "sha512-n2WbW/isZs1aU6dKeD2DPx+Nhl7l4F+5+mkhZdS2hz+uLIp462tTQR79OqBINGgH3klOs+dWpJYfXHlkdohm+w==",
       "dev": true,
       "license": "MIT"
     },
@@ -5960,7 +5960,7 @@
         "stremio-addon-sdk": "^1.6.10"
       },
       "devDependencies": {
-        "@types/stremio-addon-sdk": "^1.6.11"
+        "@types/stremio-addon-sdk": "^1.6.12"
       }
     },
     "packages/api": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "easynews-plus-plus",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "easynews-plus-plus",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "@types/express": "^5.0.1",
-        "@types/node": "^22.15.12",
+        "@types/node": "^22.15.14",
         "@vitest/coverage-v8": "^3.1.3",
         "beamup-cli": "^1.3.2",
         "bumpp": "^10.1.0",
@@ -1630,9 +1630,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.12.tgz",
-      "integrity": "sha512-K0fpC/ZVeb8G9rm7bH7vI0KAec4XHEhBam616nVJCV51bKzJ6oA3luG4WdKoaztxe70QaNjS/xBmcDLmr4PiGw==",
+      "version": "22.15.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.14.tgz",
+      "integrity": "sha512-BL1eyu/XWsFGTtDWOYULQEs4KR0qdtYfCxYAUYRoB7JP7h9ETYLgQTww6kH8Sj2C0pFGgrpM0XKv6/kbIzYJ1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "@types/express": "^5.0.1",
-        "@types/node": "^22.15.3",
+        "@types/node": "^22.15.12",
         "@vitest/coverage-v8": "^3.1.3",
         "beamup-cli": "^1.3.2",
         "bumpp": "^10.1.0",
@@ -1630,9 +1630,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
-      "integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
+      "version": "22.15.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.12.tgz",
+      "integrity": "sha512-K0fpC/ZVeb8G9rm7bH7vI0KAec4XHEhBam616nVJCV51bKzJ6oA3luG4WdKoaztxe70QaNjS/xBmcDLmr4PiGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "easynews-plus-plus",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "easynews-plus-plus",
-      "version": "2.4.2",
+      "version": "2.5.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@types/express": "^5.0.1",
-    "@types/node": "^22.15.12",
+    "@types/node": "^22.15.14",
     "beamup-cli": "^1.3.2",
     "bumpp": "^10.1.0",
     "prettier": "^3.3.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@types/express": "^5.0.1",
-    "@types/node": "^22.15.3",
+    "@types/node": "^22.15.12",
     "beamup-cli": "^1.3.2",
     "bumpp": "^10.1.0",
     "prettier": "^3.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easynews-plus-plus",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "main": "dist/server.js",
   "scripts": {
     "test": "npm run test --workspaces",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easynews-plus-plus",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "main": "dist/server.js",
   "scripts": {
     "test": "npm run test --workspaces",

--- a/packages/addon/follow-redirects.d.ts
+++ b/packages/addon/follow-redirects.d.ts
@@ -1,0 +1,36 @@
+declare module 'follow-redirects' {
+  /**
+   * A drop-in replacement for Node’s http/https with built-in redirect support.
+   * The final `responseUrl` is exposed on the IncomingMessage.
+   */
+  export const http: {
+    // Three-arg overload: (url, options, callback) for request
+    request(
+      url: string | import('url').URL,
+      options: import('http').RequestOptions & { maxRedirects?: number },
+      callback?: (res: import('http').IncomingMessage & { responseUrl?: string }) => void
+    ): import('http').ClientRequest;
+
+    // Two-arg overload: (url, options, callback) for request
+    request(
+      options: import('http').RequestOptions & { maxRedirects?: number },
+      callback?: (res: import('http').IncomingMessage & { responseUrl?: string }) => void
+    ): import('http').ClientRequest;
+
+    // Three-arg overload: (url, options, callback) for get
+    get(
+      url: string | import('url').URL,
+      options: import('http').RequestOptions & { maxRedirects?: number },
+      callback?: (res: import('http').IncomingMessage & { responseUrl?: string }) => void
+    ): import('http').ClientRequest;
+
+    // Two-arg overload: (url, options, callback) for get
+    get(
+      options: import('http').RequestOptions & { maxRedirects?: number },
+      callback?: (res: import('http').IncomingMessage & { responseUrl?: string }) => void
+    ): import('http').ClientRequest;
+  };
+
+  // Same API over HTTPS
+  export const https: typeof http;
+}

--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -14,7 +14,7 @@
   },
   "description": "Addon package for Easynews++",
   "devDependencies": {
-    "@types/stremio-addon-sdk": "^1.6.11"
+    "@types/stremio-addon-sdk": "^1.6.12"
   },
   "dependencies": {
     "easynews-plus-plus-api": "file:../api",

--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -20,6 +20,7 @@
     "easynews-plus-plus-api": "file:../api",
     "easynews-plus-plus-shared": "file:../shared",
     "parse-torrent-title": "^1.4.0",
-    "stremio-addon-sdk": "^1.6.10"
+    "stremio-addon-sdk": "^1.6.10",
+    "axios": "^1.5.0"
   }
 }

--- a/packages/addon/src/addon.ts
+++ b/packages/addon/src/addon.ts
@@ -68,7 +68,6 @@ const DEFAULT_CONFIG = {
   showQualities: '4k,1080p,720p,480p',
   maxResultsPerQuality: '0',
   maxFileSize: '0',
-  baseUrl: `http://localhost:1337`,
 };
 
 const builder = new addonBuilder(manifest);
@@ -143,7 +142,7 @@ builder.defineStreamHandler(
       showQualities = DEFAULT_CONFIG.showQualities,
       maxResultsPerQuality = DEFAULT_CONFIG.maxResultsPerQuality,
       maxFileSize = DEFAULT_CONFIG.maxFileSize,
-      baseUrl = DEFAULT_CONFIG.baseUrl,
+      baseUrl,
       ...options
     } = config;
 

--- a/packages/addon/src/addon.ts
+++ b/packages/addon/src/addon.ts
@@ -556,7 +556,12 @@ builder.defineStreamHandler(
               duration: getDuration(file),
               size: getSize(file),
               title,
-              url: `${createStreamUrl(res, username, password)}/${createStreamPath(file)}`,
+              url: createStreamUrl(
+                { downURL: res.downURL, dlFarm: res.dlFarm, dlPort: res.dlPort },
+                username,
+                password,
+                createStreamPath(file)
+              ),
               videoSize: file.rawSize,
               file,
               preferredLang,

--- a/packages/addon/src/server.ts
+++ b/packages/addon/src/server.ts
@@ -236,7 +236,6 @@ logger.info('--- Environment configuration ---');
 logger.info(`PORT: ${process.env.PORT || 'undefined'}`);
 logger.info(`LOG_LEVEL: ${logger.level || 'undefined'}`);
 logger.info(`VERSION: ${getVersion() || 'undefined'}`);
-logger.info(`BASE_URL: ${process.env.BASE_URL || 'undefined'}`);
 
 // Log API search configuration
 logger.info('--- API search configuration ---');

--- a/packages/addon/src/server.ts
+++ b/packages/addon/src/server.ts
@@ -114,6 +114,13 @@ function serveHTTP(addonInterface: AddonInterface, opts: ServerOptions = {}) {
         return;
       }
       
+      // Only accept Base64-URL with hostname easynews.com
+      const host = parsed.hostname.toLowerCase();
+      if (!host.endsWith('easynews.com')) {
+        res.status(403).send('Domain not allowed');
+        return;
+      }
+      
       // Extract and remove credentials
       const parsed = new URL(targetUrl);
       const username = parsed.searchParams.get('u') || '';

--- a/packages/addon/src/server.ts
+++ b/packages/addon/src/server.ts
@@ -94,7 +94,7 @@ function serveHTTP(addonInterface: AddonInterface, opts: ServerOptions = {}) {
     }
   });
 
-  // Proxy endpoint for stream requests
+  // Resolve endpoint for stream requests
   app.get(
     '/resolve',
     async (req: Request, res: Response, next: NextFunction): Promise<void> => {
@@ -114,7 +114,8 @@ function serveHTTP(addonInterface: AddonInterface, opts: ServerOptions = {}) {
         return;
       }
       
-      // Only accept Base64-URL with hostname easynews.com
+      // Only accept hosts under easynews.com
+      const parsed = new URL(targetUrl);
       const host = parsed.hostname.toLowerCase();
       if (!host.endsWith('easynews.com')) {
         res.status(403).send('Domain not allowed');
@@ -122,7 +123,6 @@ function serveHTTP(addonInterface: AddonInterface, opts: ServerOptions = {}) {
       }
       
       // Extract and remove credentials
-      const parsed = new URL(targetUrl);
       const username = parsed.searchParams.get('u') || '';
       const password = parsed.searchParams.get('p') || '';
       parsed.searchParams.delete('u');

--- a/packages/addon/src/server.ts
+++ b/packages/addon/src/server.ts
@@ -1,7 +1,8 @@
 import express, { Request, Response, NextFunction } from 'express';
 import { AddonInterface } from 'stremio-addon-sdk';
-import axios from 'axios';
 import { Buffer } from 'buffer';
+import { http, https } from 'follow-redirects';
+import { IncomingMessage } from 'http';
 import path from 'path';
 // Import getRouter manually since TypeScript definitions are incomplete
 // @ts-ignore
@@ -93,73 +94,68 @@ function serveHTTP(addonInterface: AddonInterface, opts: ServerOptions = {}) {
       res.end(landingHTML);
     }
   });
-
+  
   // Resolve endpoint for stream requests
-  app.get(
-    '/resolve',
-    async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-      // Expect a base64-encoded URL in the `url` query parameter
-      const encoded = req.query.url as string;
-      if (!encoded) {
-        res.status(400).send('Missing url parameter');
-        return;
-      }
-      
-      let targetUrl: string;
-      try {
-        // Decode the Base64 payload back into the Easynews URL with credentials as query-params
-        targetUrl = Buffer.from(encoded, 'base64').toString('utf-8');
-      } catch {
-        res.status(400).send('Invalid url encoding');
-        return;
-      }
-      
-      // Only accept hosts under easynews.com
-      const parsed = new URL(targetUrl);
-      const host = parsed.hostname.toLowerCase();
-      if (!host.endsWith('easynews.com')) {
-        res.status(403).send('Domain not allowed');
-        return;
-      }
-      
-      // Extract and remove credentials
-      const username = parsed.searchParams.get('u') || '';
-      const password = parsed.searchParams.get('p') || '';
-      parsed.searchParams.delete('u');
-      parsed.searchParams.delete('p');
-      const cleanUrl = parsed.toString();
-      
-      try {
-        // Perform a GET that follows redirects to the final URL (we only need headers)
-        const upstream = await axios.get(cleanUrl, {
-          auth: { username, password },
-          maxRedirects: 1,                // the final URL is provided in the first redirect
-          validateStatus: () => true,     // accept 3xx and 2xx
-          responseType: 'stream'          // stream so we don't buffer the body
-            });
-        
-        // Axios/FOLLOW-REDIRECTS attaches the final URL to:
-        const finalUrl =
-          // @ts-ignore
-          upstream.request?.res?.responseUrl ||
-          // fallback for older versions
-          (upstream.request as any)?._redirectable?._currentUrl ||
-          cleanUrl;
-        
-        if (!finalUrl) {
-          res.status(502).send('Could not determine final URL');
-          return;
-        }
-        
-        // Redirect the client to the real CDN URL
-        res.redirect(307, finalUrl);
-      } catch (err) {
-        console.error(`Error resolving final URL from ${cleanUrl}:`, err);
-        res.status(502).send('Error resolving stream');
-      }
+  app.get('/resolve', (req: Request, res: Response) => {
+    // Expect a base64-encoded URL in the `url` query parameter
+    const encoded = req.query.url as string;
+    if (!encoded) {
+      res.status(400).send('Missing url parameter');
+      return;
     }
-  );
+    
+    let targetUrl: string;
+    try {
+      // Decode the Base64 payload back into the Easynews URL with credentials as query-params
+      targetUrl = Buffer.from(encoded, 'base64').toString('utf-8');
+    } catch {
+      res.status(400).send('Invalid url encoding');
+      return;
+    }
 
+    // Only accept hosts under easynews.com
+    const parsed = new URL(targetUrl);
+    const host = parsed.hostname.toLowerCase();
+    if (!host.endsWith('easynews.com')) {
+      res.status(403).send('Domain not allowed');
+      return;
+    }
+
+    // Extract and remove credentials
+    const username = parsed.searchParams.get('u') || '';
+    const password = parsed.searchParams.get('p') || '';
+    parsed.searchParams.delete('u');
+    parsed.searchParams.delete('p');
+    const cleanUrl = parsed.toString();
+
+    // Choose the correct client
+    const client = cleanUrl.startsWith('https:') ? https : http;
+    
+    // HEAD-only request to follow redirects and get final URL  
+    const request = client.request(
+      cleanUrl,
+      {
+        method: 'HEAD',
+        headers: {
+          Authorization: 'Basic ' + Buffer.from(`${username}:${password}`).toString('base64'),
+        },
+        maxRedirects: 5,
+      },
+      // Redirect the client to the real CDN URL
+      (upstream: IncomingMessage & { responseUrl?: string }) => {
+        const finalUrl = upstream.responseUrl || cleanUrl;
+        res.redirect(307, finalUrl);
+      }
+    );
+    
+    request.on('error', (err: Error) => {
+      console.error(`Error resolving stream ${cleanUrl}:`, err);
+      res.status(502).send('Error resolving stream');
+    });
+    
+    request.end();
+  });
+ 
   if (hasConfig)
     app.get('/configure', (req: Request, res: Response) => {
       // Set no-cache headers

--- a/packages/addon/src/utils.ts
+++ b/packages/addon/src/utils.ts
@@ -344,7 +344,7 @@ export function createStreamUrl(
   const encoded = Buffer.from(authUrl).toString('base64');
   const base = process.env.BASE_URL || `http://localhost:${process.env.PORT}`;
   logger.debug(
-    `Stream URL created: ${base}/resolve?url=${encoded}`
+    `Stream URL created: ${base}/resolve?url=<encoded-easynews-url>`
   );
   return `${base}/resolve?url=${encoded}`;
 }

--- a/packages/addon/src/utils.ts
+++ b/packages/addon/src/utils.ts
@@ -5,6 +5,7 @@ import { parse as parseTorrentTitle } from 'parse-torrent-title';
 import path from 'path';
 import dotenv from 'dotenv';
 import { createLogger } from 'easynews-plus-plus-shared';
+import { Buffer } from 'buffer';
 
 // Import the custom titles JSON directly
 import customTitlesJson from '../../../custom-titles.json';
@@ -325,19 +326,27 @@ export function matchesTitle(title: string, query: string, strict: boolean) {
   return allWordsMatch;
 }
 
+/**
+ * Create a stream URL that always routes through the addon's /resolve endpoint.
+ */
 export function createStreamUrl(
   { downURL, dlFarm, dlPort }: Pick<EasynewsSearchResponse, 'downURL' | 'dlFarm' | 'dlPort'>,
   username: string,
-  password: string
-) {
+  password: string,
+  filePath: string
+): string {
   logger.debug(`Creating stream URL with farm: ${dlFarm}, port: ${dlPort}`);
-  // For streaming, we can still use the username:password@ format in the URL
-  // as it will be handled by media players, not the fetch API
-  const url = `${downURL.replace('https://', `https://${username}:${password}@`)}/${dlFarm}/${dlPort}`;
+  // Base URL without embedded credentials
+  const directUrl = `${downURL}/${dlFarm}/${dlPort}/${filePath}`;
+  // Credentials as query‐parameters
+  const authUrl = `${directUrl}?u=${encodeURIComponent(username)}&p=${encodeURIComponent(password)}`;
+  // Base64-encode and via BASE_URL (or fallback to localhost + PORT) /resolve endpoint
+  const encoded = Buffer.from(authUrl).toString('base64');
+  const base = process.env.BASE_URL || `http://localhost:${process.env.PORT}`;
   logger.debug(
-    `Stream URL created: ${url.substring(0, url.indexOf('@') + 1)}***/${dlFarm}/${dlPort}`
+    `Stream URL created: ${base}/resolve?url=${encoded}`
   );
-  return url;
+  return `${base}/resolve?url=${encoded}`;
 }
 
 export function createStreamPath(file: FileData) {

--- a/packages/addon/src/utils.ts
+++ b/packages/addon/src/utils.ts
@@ -353,9 +353,7 @@ export function createStreamUrl(
     const encoded = Buffer.from(authUrl).toString('base64');
     // Strip any trailing slash on baseUrl before concatenating
     const normalizedBase = baseUrl.replace(/\/+$/, '');
-    logger.debug(
-      `Stream URL created: ${normalizedBase}/resolve?url=<encoded-easynews-url>`
-    );
+    logger.debug(`Stream URL created: ${normalizedBase}/resolve?url=<encoded-easynews-url>`);
     return `${normalizedBase}/resolve?url=${encoded}`;
   }
 }

--- a/packages/addon/src/utils.ts
+++ b/packages/addon/src/utils.ts
@@ -334,21 +334,30 @@ export function createStreamUrl(
   username: string,
   password: string,
   filePath: string,
-  baseUrl: string
+  baseUrl?: string
 ): string {
   logger.debug(`Creating stream URL with farm: ${dlFarm}, port: ${dlPort}`);
-  // Direct URL without embedded credentials
-  const directUrl = `${downURL}/${dlFarm}/${dlPort}/${filePath}`;
-  // Credentials as query‐parameters
-  const authUrl = `${directUrl}?u=${encodeURIComponent(username)}&p=${encodeURIComponent(password)}`;
-  // Base64-encode /resolve endpoint
-  const encoded = Buffer.from(authUrl).toString('base64');
-  // Strip any trailing slash on baseUrl before concatenating
-  const normalizedBase = baseUrl.replace(/\/+$/, '');
-  logger.debug(
-    `Stream URL created: ${normalizedBase}/resolve?url=<encoded-easynews-url>`
-  );
-  return `${normalizedBase}/resolve?url=${encoded}`;
+  if (!baseUrl) {
+    // Legacy mode: credentials in URL
+    const url = `${downURL.replace('https://', `https://${username}:${password}@`)}/${dlFarm}/${dlPort}/${filePath}`;
+    logger.debug(
+      `Stream URL created: ${url.substring(0, url.indexOf('@') + 1)}***/${dlFarm}/${dlPort}/${filePath}`
+    );
+    return url;
+  } else {
+    // Resolve mode: route via addon
+    const url = `${downURL}/${dlFarm}/${dlPort}/${filePath}`;
+    // Credentials as query‐parameters
+    const authUrl = `${url}?u=${encodeURIComponent(username)}&p=${encodeURIComponent(password)}`;
+    // Base64-encode /resolve endpoint
+    const encoded = Buffer.from(authUrl).toString('base64');
+    // Strip any trailing slash on baseUrl before concatenating
+    const normalizedBase = baseUrl.replace(/\/+$/, '');
+    logger.debug(
+      `Stream URL created: ${normalizedBase}/resolve?url=<encoded-easynews-url>`
+    );
+    return `${normalizedBase}/resolve?url=${encoded}`;
+  }
 }
 
 export function createStreamPath(file: FileData) {

--- a/packages/addon/tests/utils.test.ts
+++ b/packages/addon/tests/utils.test.ts
@@ -359,8 +359,8 @@ describe('createStreamUrl', () => {
       dlPort: 'port1',
     } as unknown as any;
 
-    const url = createStreamUrl(response, 'testuser', 'testpass');
-    expect(url).toBe('https://testuser:testpass@example.com/down/farm1/port1');
+    const url = createStreamUrl(response, 'testuser', 'testpass', '');
+    expect(url).toBe('https://testuser:testpass@example.com/down/farm1/port1/');
   });
 
   it('handles different URL formats', () => {
@@ -370,10 +370,38 @@ describe('createStreamUrl', () => {
       dlPort: 'port2',
     } as unknown as any;
 
-    const url = createStreamUrl(response, 'user@domain.com', 'complex@pass!123');
+    const url = createStreamUrl(response, 'user@domain.com', 'complex@pass!123', '');
     expect(url).toBe(
-      'https://user@domain.com:complex@pass!123@cdn.example.com/download/farm2/port2'
+      'https://user@domain.com:complex@pass!123@cdn.example.com/download/farm2/port2/'
     );
+  });
+
+  it('includes the file path parameter in the URL', () => {
+    const response = {
+      downURL: 'https://example.com/down',
+      dlFarm: 'farm1',
+      dlPort: 'port1',
+    } as unknown as any;
+
+    const url = createStreamUrl(response, 'testuser', 'testpass', 'abc123.mp4/video.mp4');
+    expect(url).toBe('https://testuser:testpass@example.com/down/farm1/port1/abc123.mp4/video.mp4');
+  });
+
+  it('handles baseUrl parameter for the resolver mode', () => {
+    const response = {
+      downURL: 'https://example.com/down',
+      dlFarm: 'farm1',
+      dlPort: 'port1',
+    } as unknown as any;
+
+    const url = createStreamUrl(
+      response,
+      'testuser',
+      'testpass',
+      'abc123.mp4/video.mp4',
+      'https://addon.example.com'
+    );
+    expect(url).toContain('https://addon.example.com/resolve?url=');
   });
 });
 

--- a/packages/addon/tsconfig.json
+++ b/packages/addon/tsconfig.json
@@ -7,7 +7,7 @@
     "composite": true,
     "declaration": true
   },
-  "include": ["src/**/*", "stremio-addon-sdk-builder.d.ts", "stremio-addon-sdk.d.ts"],
+  "include": ["src/**/*", "stremio-addon-sdk-builder.d.ts", "stremio-addon-sdk.d.ts", "follow-redirects.d.ts"],
   "exclude": ["**/*.test.ts"],
   "references": [
     {

--- a/packages/addon/tsconfig.json
+++ b/packages/addon/tsconfig.json
@@ -7,7 +7,12 @@
     "composite": true,
     "declaration": true
   },
-  "include": ["src/**/*", "stremio-addon-sdk-builder.d.ts", "stremio-addon-sdk.d.ts", "follow-redirects.d.ts"],
+  "include": [
+    "src/**/*",
+    "stremio-addon-sdk-builder.d.ts",
+    "stremio-addon-sdk.d.ts",
+    "follow-redirects.d.ts"
+  ],
   "exclude": ["**/*.test.ts"],
   "references": [
     {

--- a/packages/cloudflare-worker/package.json
+++ b/packages/cloudflare-worker/package.json
@@ -19,6 +19,6 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250507.0",
-    "wrangler": "^4.14.2"
+    "wrangler": "^4.14.3"
   }
 }

--- a/packages/cloudflare-worker/package.json
+++ b/packages/cloudflare-worker/package.json
@@ -19,6 +19,6 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250505.0",
-    "wrangler": "^4.14.1"
+    "wrangler": "^4.14.2"
   }
 }

--- a/packages/cloudflare-worker/package.json
+++ b/packages/cloudflare-worker/package.json
@@ -18,7 +18,7 @@
     "hono-stremio": "^0.1.1"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250505.0",
+    "@cloudflare/workers-types": "^4.20250507.0",
     "wrangler": "^4.14.2"
   }
 }

--- a/packages/cloudflare-worker/src/index.ts
+++ b/packages/cloudflare-worker/src/index.ts
@@ -39,6 +39,60 @@ function createManifestWithLanguage(lang: string) {
   return manifest;
 }
 
+// Add resolve endpoint for stream requests
+app.get('/resolve', async c => {
+  // Expect a base64-encoded URL in the `url` query parameter
+  const encoded = c.req.query('url');
+  if (!encoded) {
+    return c.text('Missing url parameter', 400);
+  }
+
+  let targetUrl: string;
+  try {
+    // Decode the Base64 payload back into the Easynews URL with credentials as query-params
+    targetUrl = atob(encoded);
+  } catch {
+    return c.text('Invalid url encoding', 400);
+  }
+
+  // Only accept hosts under easynews.com
+  const parsed = new URL(targetUrl);
+  const host = parsed.hostname.toLowerCase();
+  if (!host.endsWith('easynews.com')) {
+    return c.text('Domain not allowed', 403);
+  }
+
+  // Extract and remove credentials
+  const username = parsed.searchParams.get('u') || '';
+  const password = parsed.searchParams.get('p') || '';
+  parsed.searchParams.delete('u');
+  parsed.searchParams.delete('p');
+  const cleanUrl = parsed.toString();
+
+  try {
+    // Create authorization header
+    const auth = 'Basic ' + btoa(`${username}:${password}`);
+
+    // Make HEAD request to follow redirect and get final URL
+    const response = await fetch(cleanUrl, {
+      method: 'HEAD',
+      headers: {
+        Authorization: auth,
+      },
+      redirect: 'manual',
+    });
+
+    // If we got a 3xx, grab the Location header; otherwise fall back
+    const location = response.headers.get('Location') || cleanUrl;
+
+    // Redirect to the final URL
+    return c.redirect(location, 307);
+  } catch (err) {
+    logger.error(`Error resolving stream ${cleanUrl}:`, err);
+    return c.text('Error resolving stream', 502);
+  }
+});
+
 // Add the configure route for direct access with language selection
 app.get('/configure', c => {
   logger.info(`Received configure request from: ${c.req.header('user-agent')}`);


### PR DESCRIPTION
Enable stream resolution via `/resolve` endpoint to hand out the final, public stream URL. This resolver preserves byte‐range requests for seamless playback and ensures all subsequent media data flows directly from the EasyNews CDN.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new `/resolve` endpoint for enhanced stream URL handling, improving security and compatibility.
  - Added support for customizing the base URL in addon configurations and stream URL generation.

- **Improvements**
  - Android TV is now listed as fully supported in the platform compatibility documentation.
  - Enhanced stream URLs now pass credentials securely as query parameters instead of embedding them in the URL.

- **Dependency Updates**
  - Added `axios` as a dependency in the addon package.

- **Other Changes**
  - Incremented package version to 2.6.0.
  - Minor updates to example and configuration files.
  - Improved type safety and test coverage for new URL handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->