### PR TITLE
feat: add filename segment to resolve URLs

### DIFF
--- a/packages/addon/src/server.ts
+++ b/packages/addon/src/server.ts
@@ -96,10 +96,11 @@ function serveHTTP(addonInterface: AddonInterface, opts: ServerOptions = {}) {
   });
 
   // Resolve endpoint for stream requests
-  app.get('/resolve', (req: Request, res: Response) => {
-    // Expect a base64-encoded URL in the `url` query parameter
-    const encoded = req.query.url as string;
-    if (!encoded) {
+  app.get('/resolve/:payload/:filename', async (req: Request, res: Response) => {
+    // Expect a base64-encoded URL in the payload
+    const { payload }  = req.params;
+    const encodedUrl   = payload as string;
+    if (!encodedUrl) {
       res.status(400).send('Missing url parameter');
       return;
     }
@@ -107,7 +108,7 @@ function serveHTTP(addonInterface: AddonInterface, opts: ServerOptions = {}) {
     let targetUrl: string;
     try {
       // Decode the Base64 payload back into the Easynews URL with credentials as query-params
-      targetUrl = Buffer.from(encoded, 'base64').toString('utf-8');
+      targetUrl = Buffer.from(encodedUrl, 'base64').toString('utf-8');
     } catch {
       res.status(400).send('Invalid url encoding');
       return;

--- a/packages/addon/src/server.ts
+++ b/packages/addon/src/server.ts
@@ -117,7 +117,8 @@ function serveHTTP(addonInterface: AddonInterface, opts: ServerOptions = {}) {
     // Only accept hosts under easynews.com
     const parsed = new URL(targetUrl);
     const host = parsed.hostname.toLowerCase();
-    if (!host.endsWith('easynews.com')) {
+    const allowedDomain = /^([a-z0-9-]+\.)*easynews\.com$/i;
+    if (!allowedDomain.test(host)) {
       res.status(403).send('Domain not allowed');
       return;
     }

--- a/packages/addon/src/utils.ts
+++ b/packages/addon/src/utils.ts
@@ -349,12 +349,15 @@ export function createStreamUrl(
     const url = `${downURL}/${dlFarm}/${dlPort}/${filePath}`;
     // Credentials as query‐parameters
     const authUrl = `${url}?u=${encodeURIComponent(username)}&p=${encodeURIComponent(password)}`;
-    // Base64-encode /resolve endpoint
-    const encoded = Buffer.from(authUrl).toString('base64');
+    // Base64-encode authUrl
+    const encodedUrl = Buffer.from(authUrl).toString('base64');
+    // Extract the filename
+    const fileName = path.basename(filePath);
     // Strip any trailing slash on baseUrl before concatenating
     const normalizedBase = baseUrl.replace(/\/+$/, '');
-    logger.debug(`Stream URL created: ${normalizedBase}/resolve?url=<encoded-easynews-url>`);
-    return `${normalizedBase}/resolve?url=${encoded}`;
+    // Build /resolve/<base64-payload>/<filename>
+    logger.debug(`Stream URL created: ${normalizedBase}/resolve/<encoded-easynews-url>/${fileName}`);
+    return `${normalizedBase}/resolve/${encodedUrl}/${fileName}`;
   }
 }
 

--- a/packages/cloudflare-worker/src/index.ts
+++ b/packages/cloudflare-worker/src/index.ts
@@ -40,17 +40,17 @@ function createManifestWithLanguage(lang: string) {
 }
 
 // Add resolve endpoint for stream requests
-app.get('/resolve', async c => {
-  // Expect a base64-encoded URL in the `url` query parameter
-  const encoded = c.req.query('url');
-  if (!encoded) {
+app.get('/resolve/:payload/:filename', async c => {
+  // Expect a base64-encoded URL in the payload
+  const encodedUrl = c.req.param('payload');
+  if (!encodedUrl) {
     return c.text('Missing url parameter', 400);
   }
 
   let targetUrl: string;
   try {
     // Decode the Base64 payload back into the Easynews URL with credentials as query-params
-    targetUrl = atob(encoded);
+    targetUrl = atob(encodedUrl);
   } catch {
     return c.text('Invalid url encoding', 400);
   }
@@ -58,7 +58,8 @@ app.get('/resolve', async c => {
   // Only accept hosts under easynews.com
   const parsed = new URL(targetUrl);
   const host = parsed.hostname.toLowerCase();
-  if (!host.endsWith('easynews.com')) {
+  const allowedDomain = /^([a-z0-9-]+\.)*easynews\.com$/i;
+  if (!allowedDomain.test(host)) {
     return c.text('Domain not allowed', 403);
   }
 


### PR DESCRIPTION
Update createStreamUrl and /resolve routes to emit and accept URLs in the form /resolve/<base64-payload>/<filename>. Strengthen safeguards against misuse of the stream resolver, ensuring it is only used for Easynews domains and subdomains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the URL structure for resolving links, now using path parameters instead of query parameters for improved clarity and consistency.
- **Improvements**
	- Enhanced domain validation to better support subdomains when resolving URLs.
- **Bug Fixes**
	- Adjusted internal link generation and resolution to ensure compatibility with the new URL structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->