### PR TITLE
fix: switch resolve endpoint to GET+Range and URL-safe Base64URL encoding

### DIFF
--- a/packages/addon/src/utils.ts
+++ b/packages/addon/src/utils.ts
@@ -349,8 +349,8 @@ export function createStreamUrl(
     const url = `${downURL}/${dlFarm}/${dlPort}/${filePath}`;
     // Credentials as query‐parameters
     const authUrl = `${url}?u=${encodeURIComponent(username)}&p=${encodeURIComponent(password)}`;
-    // Base64-encode authUrl
-    const encodedUrl = Buffer.from(authUrl).toString('base64');
+    // Base64URL-encode authUrl
+    const encodedUrl = Buffer.from(authUrl).toString('base64url');
     // Extract the filename
     const fileName = path.basename(filePath);
     // Strip any trailing slash on baseUrl before concatenating


### PR DESCRIPTION
Change upstream resolution from HTTP HEAD to GET with Range: bytes=0-0 to reliably capture 3xx redirects (especially in Cloudflare Workers).

Adopt Base64URL encoding instead of standard Base64 to ensure stream payloads remain URL-safe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved URL encoding by switching from Base64 to Base64URL for safer and more reliable URL handling.
  - Enhanced redirect resolution by changing the HTTP request method to minimize data transfer while ensuring correct redirect behavior.

- **Documentation**
  - Updated comments to accurately reflect the changes in encoding and request methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->